### PR TITLE
Added $resource parameter to getBaseSelfUrl method

### DIFF
--- a/src/Schema/SchemaProvider.php
+++ b/src/Schema/SchemaProvider.php
@@ -157,15 +157,16 @@ abstract class SchemaProvider implements SchemaProviderInterface
      */
     public function getSelfUrl($resource)
     {
-        return $this->getBaseSelfUrl() . $this->getId($resource);
+        return $this->getBaseSelfUrl($resource) . $this->getId($resource);
     }
 
     /**
      * Get the base self URL
      *
+     * @param object $resource
      * @return string
      */
-    protected function getBaseSelfUrl()
+    protected function getBaseSelfUrl($resource)
     {
         assert('is_string($this->baseSelfUrl) && empty($this->baseSelfUrl) === false', 'Base \'self\' not set.');
 


### PR DESCRIPTION
Duh! Obviously didn't think this all the way through in #4. Anyways, the $resource parameter now gets passed as well to getBaseSelfUrl.
