### PR TITLE
Fix encoding of empty Iterator.

### DIFF
--- a/src/Encoder/Parser/DataAnalyzer.php
+++ b/src/Encoder/Parser/DataAnalyzer.php
@@ -63,6 +63,8 @@ class DataAnalyzer implements DataAnalyzerInterface
             if ($isEmpty === false) {
                 $firstItem       = $data->current();
                 $traversableData = $data;
+            } else {
+                $traversableData = [];
             }
         } elseif (is_object($data) === true) {
             /** @var object $data */

--- a/tests/Encoder/EncodeSimpleObjectsTest.php
+++ b/tests/Encoder/EncodeSimpleObjectsTest.php
@@ -86,6 +86,28 @@ EOL;
     }
 
     /**
+     * Test encode empty iterator.
+     */
+    public function testEncodeEmptyIterator()
+    {
+        $encoder = Encoder::instance([
+            Author::class => AuthorSchema::class,
+        ]);
+
+        $actual = $encoder->encode(new \ArrayIterator([]));
+
+        $expected = <<<EOL
+        {
+            "data": []
+        }
+EOL;
+        // remove formatting from 'expected'
+        $expected = json_encode(json_decode($expected));
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
      * Test encode empty array.
      *
      * Issue #50 @link https://github.com/neomerx/json-api/issues/50


### PR DESCRIPTION
Currently passing an empty iterator to encode results in the following:

``` json
{
    "data": null
}
```

According to the spec, for endpoints resulting in collections the data member must be:

> an array of resource objects, an array of resource identifier objects, or an empty array ([]), for requests that target resource collections

So I believe this is a bug. This pull requests adds a test and the fix.
