### PR TITLE
Refactor RenderContainerInterface

### DIFF
--- a/src/Contracts/Exceptions/RenderContainerInterface.php
+++ b/src/Contracts/Exceptions/RenderContainerInterface.php
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-use \Closure;
 use \Exception;
+use Neomerx\JsonApi\Contracts\Exceptions\Renderer\ExceptionRendererInterface;
 
 /**
  * @package Neomerx\JsonApi
@@ -28,11 +28,10 @@ interface RenderContainerInterface
      * Register exception render
      *
      * @param string  $exceptionClass
-     * @param Closure $render
-     *
+     * @param ExceptionRendererInterface $render
      * @return void
      */
-    public function registerRender($exceptionClass, Closure $render);
+    public function registerRenderer($exceptionClass, ExceptionRendererInterface $render);
 
     /**
      * Register HTTP status code mapping for exceptions.
@@ -56,8 +55,7 @@ interface RenderContainerInterface
      * Get registered or default render for exception.
      *
      * @param Exception $exception
-     *
-     * @return Closure
+     * @return ExceptionRendererInterface
      */
-    public function getRender(Exception $exception);
+    public function getRenderer(Exception $exception);
 }

--- a/src/Contracts/Exceptions/Renderer/ExceptionRendererInterface.php
+++ b/src/Contracts/Exceptions/Renderer/ExceptionRendererInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Neomerx\JsonApi\Contracts\Exceptions\Renderer;
+
+use Neomerx\JsonApi\Contracts\Encoder\EncoderInterface;
+use Neomerx\JsonApi\Contracts\Parameters\Headers\MediaTypeInterface;
+use Neomerx\JsonApi\Contracts\Parameters\SupportedExtensionsInterface;
+
+/**
+ * Interface ExceptionRendererInterface
+ * @package Neomerx\JsonApi
+ */
+interface ExceptionRendererInterface
+{
+
+    /**
+     * @param $statusCode
+     * @return $this
+     */
+    public function withStatusCode($statusCode);
+
+    /**
+     * @param array $headers
+     * @return $this
+     */
+    public function withHeaders(array $headers);
+
+    /**
+     * @param SupportedExtensionsInterface $extensions
+     * @return $this
+     */
+    public function withSupportedExtensions(SupportedExtensionsInterface $extensions);
+
+    /**
+     * @param MediaTypeInterface $mediaType
+     * @return $this
+     */
+    public function withMediaType(MediaTypeInterface $mediaType);
+
+    /**
+     * @param EncoderInterface $encoder
+     * @return $this
+     */
+    public function withEncoder(EncoderInterface $encoder);
+
+    /**
+     * @param \Exception $e
+     * @return mixed
+     */
+    public function render(\Exception $e);
+}

--- a/src/Exceptions/Renderer/ErrorsRenderer.php
+++ b/src/Exceptions/Renderer/ErrorsRenderer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Neomerx\JsonApi\Exceptions\Renderer;
+
+use Neomerx\JsonApi\Contracts\Document\ErrorInterface;
+use Neomerx\JsonApi\Contracts\Exceptions\Renderer\ExceptionRendererInterface;
+use Neomerx\JsonApi\Contracts\Responses\ResponsesInterface;
+
+/**
+ * Class ErrorsRenderer
+ * @package Neomerx\JsonApi
+ */
+class ErrorsRenderer implements ExceptionRendererInterface
+{
+
+    use ExceptionRendererTrait;
+
+    /**
+     * @var ResponsesInterface
+     */
+    protected $responses;
+
+    /**
+     * @param ResponsesInterface $responses
+     */
+    public function __construct(ResponsesInterface $responses)
+    {
+        $this->responses = $responses;
+    }
+
+    /**
+     * @param \Exception $e
+     * @return mixed
+     */
+    public function render(\Exception $e)
+    {
+        /** Handle this safely so that a new Exception is not trigger while rendering a previous exception. */
+        $content = ($e instanceof ErrorInterface) ? $this->getEncoder()->encodeErrors([$e]) : null;
+
+        return $this->responses->getResponse(
+            $this->getStatusCode(),
+            $this->getMediaType(),
+            $content,
+            $this->getSupportedExtensions(),
+            $this->getHeaders()
+        );
+    }
+}

--- a/src/Exceptions/Renderer/ExceptionRendererTrait.php
+++ b/src/Exceptions/Renderer/ExceptionRendererTrait.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Neomerx\JsonApi\Exceptions\Renderer;
+
+use Neomerx\JsonApi\Contracts\Encoder\EncoderInterface;
+use Neomerx\JsonApi\Contracts\Parameters\Headers\MediaTypeInterface;
+use Neomerx\JsonApi\Contracts\Parameters\SupportedExtensionsInterface;
+use Neomerx\JsonApi\Encoder\Encoder;
+use Neomerx\JsonApi\Parameters\Headers\MediaType;
+
+/**
+ * Class ExceptionRendererTrait
+ * @package Neomerx\JsonApi
+ */
+trait ExceptionRendererTrait
+{
+
+    /**
+     * @var int|null
+     */
+    protected $_statusCode;
+
+    /**
+     * @var array|null
+     */
+    protected $_headers;
+
+    /**
+     * @var SupportedExtensionsInterface|null
+     */
+    protected $_extensions;
+
+    /**
+     * @var MediaTypeInterface|null
+     */
+    protected $_mediaType;
+
+    /**
+     * @var EncoderInterface|null
+     */
+    protected $_encoder;
+
+    /**
+     * @param $statusCode
+     * @return $this
+     */
+    public function withStatusCode($statusCode)
+    {
+        $this->_statusCode = (int) $statusCode;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getStatusCode()
+    {
+        return $this->hasStatusCode() ? (int) $this->_statusCode : 500;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasStatusCode()
+    {
+        return $this->isStatusCode($this->_statusCode);
+    }
+
+    /**
+     * @param $statusCode
+     * @return bool
+     */
+    public function isStatusCode($statusCode)
+    {
+        return (400 <= $statusCode && 600 > $statusCode);
+    }
+
+    /**
+     * @param array $headers
+     * @return $this
+     */
+    public function withHeaders(array $headers)
+    {
+        $this->_headers = $headers;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getHeaders()
+    {
+        return (array) $this->_headers;
+    }
+
+    /**
+     * @param SupportedExtensionsInterface $extensions
+     * @return $this
+     */
+    public function withSupportedExtensions(SupportedExtensionsInterface $extensions)
+    {
+        $this->_extensions = $extensions;
+
+        return $this;
+    }
+
+    /**
+     * @return SupportedExtensionsInterface|null
+     */
+    public function getSupportedExtensions()
+    {
+        return $this->_extensions;
+    }
+
+    /**
+     * @param MediaTypeInterface $mediaType
+     * @return $this
+     */
+    public function withMediaType(MediaTypeInterface $mediaType)
+    {
+        $this->_mediaType = $mediaType;
+
+        return $this;
+    }
+
+    /**
+     * @return MediaTypeInterface
+     */
+    public function getMediaType()
+    {
+        if ($this->_mediaType instanceof MediaTypeInterface) {
+            return $this->_mediaType;
+        }
+
+        return new MediaType(MediaTypeInterface::JSON_API_TYPE, MediaTypeInterface::JSON_API_SUB_TYPE);
+    }
+
+    /**
+     * @param EncoderInterface $encoder
+     * @return $this
+     */
+    public function withEncoder(EncoderInterface $encoder)
+    {
+        $this->_encoder = $encoder;
+
+        return $this;
+    }
+
+    /**
+     * @return EncoderInterface
+     */
+    public function getEncoder()
+    {
+        if (!$this->_encoder instanceof EncoderInterface) {
+            $this->_encoder = Encoder::instance([]);
+        }
+
+        return $this->_encoder;
+    }
+}

--- a/src/Exceptions/Renderer/ExceptionRendererTrait.php
+++ b/src/Exceptions/Renderer/ExceptionRendererTrait.php
@@ -73,7 +73,7 @@ trait ExceptionRendererTrait
      */
     public function isStatusCode($statusCode)
     {
-        return (400 <= $statusCode && 600 > $statusCode);
+        return (100 <= $statusCode && 600 > $statusCode);
     }
 
     /**

--- a/src/Exceptions/Renderer/HttpCodeRenderer.php
+++ b/src/Exceptions/Renderer/HttpCodeRenderer.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Neomerx\JsonApi\Exceptions\Renderer;
+
+use Neomerx\JsonApi\Contracts\Exceptions\Renderer\ExceptionRendererInterface;
+use Neomerx\JsonApi\Contracts\Responses\ResponsesInterface;
+
+/**
+ * Class HttpCodeRenderer
+ * @package Neomerx\JsonApi
+ */
+class HttpCodeRenderer implements ExceptionRendererInterface
+{
+
+    use ExceptionRendererTrait;
+
+    /**
+     * @var ResponsesInterface
+     */
+    protected $responses;
+
+    /**
+     * @param ResponsesInterface $responses
+     */
+    public function __construct(ResponsesInterface $responses)
+    {
+        $this->responses = $responses;
+    }
+
+    /**
+     * @param \Exception $e
+     * @return mixed
+     */
+    public function render(\Exception $e)
+    {
+        return $this->responses->getResponse(
+            $this->getStatusCode(),
+            $this->getMediaType(),
+            null,
+            $this->getSupportedExtensions(),
+            $this->getHeaders()
+        );
+    }
+
+}

--- a/src/Exceptions/ThrowableError.php
+++ b/src/Exceptions/ThrowableError.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Neomerx\JsonApi\Exceptions;
+
+use Neomerx\JsonApi\Contracts\Document\ErrorInterface;
+use Neomerx\JsonApi\Contracts\Schema\LinkInterface;
+
+/**
+ * Class ThrowableError
+ * @package Neomerx\JsonApi
+ */
+class ThrowableError extends \RuntimeException implements ErrorInterface
+{
+
+    /**
+     * @var int|string|null
+     */
+    private $idx;
+
+    /**
+     * @var null|array<string,\Neomerx\JsonApi\Contracts\Schema\LinkInterface>
+     */
+    private $links;
+
+    /**
+     * @var string|null
+     */
+    private $status;
+
+    /**
+     * @var string|null
+     */
+    private $title;
+
+    /**
+     * @var string|null
+     */
+    private $detail;
+
+    /**
+     * @var mixed|null
+     */
+    private $source;
+
+    /**
+     * @var array|null
+     */
+    private $meta;
+
+    /**
+     * @param int|string|null    $idx
+     * @param LinkInterface|null $aboutLink
+     * @param string|null        $status
+     * @param string|null        $code
+     * @param string|null        $title
+     * @param string|null        $detail
+     * @param array|null         $source
+     * @param array|null         $meta
+     * @param \Exception|null     $previous
+     *
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+     */
+    public function __construct(
+        $idx = null,
+        LinkInterface $aboutLink = null,
+        $status = null,
+        $code = null,
+        $title = null,
+        $detail = null,
+        array $source = null,
+        array $meta = null,
+        \Exception $previous = null
+    ) {
+        parent::__construct($title, $code, $previous);
+
+        $this->idx = $idx;
+        $this->links = $aboutLink;
+        $this->status = $status;
+        $this->title = $title;
+        $this->detail = $detail;
+        $this->source = $source;
+        $this->meta = $meta;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getId()
+    {
+        return $this->idx;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getLinks()
+    {
+        return $this->links;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDetail()
+    {
+        return $this->detail;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getSource()
+    {
+        return $this->source;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMeta()
+    {
+        return $this->meta;
+    }
+}


### PR DESCRIPTION
If your framework's implementation of `RenderContainerInterface` is being returned from the framework's service container, there's no way of knowing what function arguments should be passed into the `Closure` that it currently returns.

The solution is for there to be a standard interface for Exception renderers. This pull request introduces an `ExceptionRendererInterface` and updates `RenderContainerInterface` so that it specifies the new interface as its return type.

This implementation solves the additional use case of wanting to use a `CodecMatcherInterface` to provide the encoder that is used for Exception rendering. In this new implementation, a consumer of the `RenderContainerInterface` can also be injected with a `CodecMatcherInterface` and can use the matched encoder at exception render time.

The pull request also updates the existing `RenderContainer` so that it works in the same way with these new interfaces. (At the same time I've changed the constructor dependency from `NativeResponsesInterface` to `ResponsesInterface` because the actual dependency is with `ResponsesInterface`.)

I've also added in a `ThrowableError` class, which is an `Exception` that implements `ErrorInterface`. This was required for testing but is also useful in actual framework implementations. (I've used your Limencello exception as a copy and paste for this.)
