### PR TITLE
Refactor CodecMatcherInterface

### DIFF
--- a/src/Contracts/Codec/CodecMatcherInterface.php
+++ b/src/Contracts/Codec/CodecMatcherInterface.php
@@ -1,4 +1,6 @@
-<?php namespace Neomerx\JsonApi\Contracts\Codec;
+<?php
+
+namespace Neomerx\JsonApi\Contracts\Codec;
 
 /**
  * Copyright 2015 info@neomerx.com (www.neomerx.com)
@@ -22,20 +24,19 @@ use \Neomerx\JsonApi\Contracts\Encoder\EncoderInterface;
 use \Neomerx\JsonApi\Contracts\Parameters\Headers\HeaderInterface;
 use \Neomerx\JsonApi\Contracts\Parameters\Headers\MediaTypeInterface;
 use \Neomerx\JsonApi\Contracts\Parameters\Headers\AcceptHeaderInterface;
-use \Neomerx\JsonApi\Contracts\Parameters\Headers\AcceptMediaTypeInterface;
 
 /**
  * @package Neomerx\JsonApi
  */
 interface CodecMatcherInterface
 {
+
     /**
      * Register encoder.
      *
      * @param MediaTypeInterface $mediaType
      * @param Closure            $encoderClosure
-     *
-     * @return void
+     * @return $this
      */
     public function registerEncoder(MediaTypeInterface $mediaType, Closure $encoderClosure);
 
@@ -44,49 +45,73 @@ interface CodecMatcherInterface
      *
      * @param MediaTypeInterface $mediaType
      * @param Closure            $decoderClosure
-     *
-     * @return void
+     * @return $this
      */
     public function registerDecoder(MediaTypeInterface $mediaType, Closure $decoderClosure);
 
     /**
-     * Get encoder.
-     *
-     * @return EncoderInterface|null
+     * @param MediaTypeInterface $mediaType
+     * @param Closure $encoder
+     * @param Closure $decoder
+     * @return $this
      */
-    public function getEncoder();
+    public function registerBoth(MediaTypeInterface $mediaType, Closure $encoder, Closure $decoder);
 
     /**
-     * Set encoder.
+     * Register the default media type that should be used if match is not found.
+     *
+     * A default media type is required for instances where a fallback encoder is required. For example, if an error
+     * needs to be encoded but the error was caused by there not being an encoder match, a renderer will need a fallback
+     * encoder to use.
+     *
+     * @param MediaTypeInterface $mediaType
+     * @return $this
+     */
+    public function registerDefault(MediaTypeInterface $mediaType);
+
+    /**
+     * @return EncoderMatchInterface
+     */
+    public function getDefaultEncoder();
+
+    /**
+     * Get the matched encoder, or null if no match.
+     *
+     * @return EncoderMatchInterface|null
+     */
+    public function getEncoderMatch();
+
+    /**
+     * Set the matched encoder.
      *
      * @param EncoderInterface|Closure $encoder
-     *
-     * @return void
+     * @param MediaTypeInterface $mediaType
+     * @return $this
      */
-    public function setEncoder($encoder);
+    public function setEncoder($encoder, MediaTypeInterface $mediaType);
 
     /**
-     * Get decoder.
+     * Get the matched decoder, or null if no match.
      *
-     * @return DecoderInterface|null
+     * @return DecoderMatchInterface|null
      */
-    public function getDecoder();
+    public function getDecoderMatch();
 
     /**
-     * Set decoder.
+     * Set the matched decoder.
      *
      * @param DecoderInterface|Closure $decoder
-     *
-     * @return DecoderInterface
+     * @param MediaTypeInterface $mediaType
+     * @return mixed
      */
-    public function setDecoder($decoder);
+    public function setDecoder($decoder, MediaTypeInterface $mediaType);
 
     /**
      * Find best encoder match for 'Accept' header.
      *
      * @param AcceptHeaderInterface $acceptHeader
-     *
-     * @return void
+     * @return EncoderMatchInterface|null
+     *      the encoder that was matched, or null if none.
      */
     public function matchEncoder(AcceptHeaderInterface $acceptHeader);
 
@@ -94,36 +119,9 @@ interface CodecMatcherInterface
      * Find best decoder match for 'Content-Type' header.
      *
      * @param HeaderInterface $contentTypeHeader
-     *
-     * @return void
+     * @return DecoderMatchInterface|null
+     *      the decoder that was found, or nll if none.
      */
     public function findDecoder(HeaderInterface $contentTypeHeader);
 
-    /**
-     * Get media type from 'Accept' header that matched to one of the registered encoder media types.
-     *
-     * @return AcceptMediaTypeInterface|null
-     */
-    public function getEncoderHeaderMatchedType();
-
-    /**
-     * Get media type that was registered for matched encoder.
-     *
-     * @return MediaTypeInterface|null
-     */
-    public function getEncoderRegisteredMatchedType();
-
-    /**
-     * Get media type from 'Content-Type' header that matched to one of the registered decoder media types.
-     *
-     * @return MediaTypeInterface|null
-     */
-    public function getDecoderHeaderMatchedType();
-
-    /**
-     * Get media type that was registered for matched decoder.
-     *
-     * @return MediaTypeInterface|null
-     */
-    public function getDecoderRegisteredMatchedType();
 }

--- a/src/Contracts/Codec/DecoderMatchInterface.php
+++ b/src/Contracts/Codec/DecoderMatchInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Neomerx\JsonApi\Contracts\Codec;
+
+use Neomerx\JsonApi\Contracts\Decoder\DecoderInterface;
+use Neomerx\JsonApi\Contracts\Parameters\Headers\AcceptMediaTypeInterface;
+use Neomerx\JsonApi\Contracts\Parameters\Headers\MediaTypeInterface;
+
+interface DecoderMatchInterface
+{
+
+    /**
+     * @return DecoderInterface
+     */
+    public function getDecoder();
+
+    /**
+     * Get media type from 'Content-Type' header that matched to the decoder media types.
+     *
+     * @return AcceptMediaTypeInterface|null
+     */
+    public function getHeaderType();
+
+    /**
+     * Get media type that was registered for matched decoder.
+     *
+     * @return MediaTypeInterface
+     */
+    public function getRegisteredType();
+}

--- a/src/Contracts/Codec/EncoderMatchInterface.php
+++ b/src/Contracts/Codec/EncoderMatchInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Neomerx\JsonApi\Contracts\Codec;
+
+use Neomerx\JsonApi\Contracts\Encoder\EncoderInterface;
+use Neomerx\JsonApi\Contracts\Parameters\Headers\AcceptMediaTypeInterface;
+use Neomerx\JsonApi\Contracts\Parameters\Headers\MediaTypeInterface;
+
+interface EncoderMatchInterface
+{
+
+    /**
+     * @return EncoderInterface
+     */
+    public function getEncoder();
+
+    /**
+     * Get media type from 'Accept' header that matched to the encoder media types.
+     *
+     * @return AcceptMediaTypeInterface|null
+     */
+    public function getHeaderType();
+
+    /**
+     * Get media type that was registered for matched encoder.
+     *
+     * @return MediaTypeInterface
+     */
+    public function getRegisteredType();
+}


### PR DESCRIPTION
This is a suggestion on making the `CodecMatcherInterface` easier to use. I'm finding that generally the times when I interact with it I need to get the combination of the encoder/decoder plus the media type together - i.e. the two related. 

I also find that there are scenarios where I need a fallback encoder - i.e. if an encoder has not matched, I still want to use one of the encoders registered within the codec matcher. Because the codec matcher usually comes from a service provider, the client code doesn't know what's in the container and what it should use the fallback. 

I think the following changes help sort this out:
1. Return matches as either `EncoderMatchInterface` or `DecoderMatchInterface`, that hold the combination of encoder/decoder, registered media type and the header that was used to match (if applicable).
2. Add `getDefaultEncoder` and `getDefaultDecoder` methods. This is set by calling `registerDefault` with a `MediaTypeInterface` that is used to match the defaults.
3. Make the register methods chainable to make registering types more fluent. Add a `registerBoth` method to register an encoder and decoder to the same media type.

I haven't written the actual implementations so the tests will fail. If the interface changes are acceptable I'll add the implementations and tests.
