### PR TITLE
fix lazy loaded entities type for Doctrine

### DIFF
--- a/src/Schema/Container.php
+++ b/src/Schema/Container.php
@@ -54,6 +54,11 @@ class Container implements ContainerInterface, LoggerAwareInterface
     private $factory;
 
     /**
+     * @var string
+     */
+    const DOCTRINE_PROXY_CLASS_NAME = 'Doctrine\ORM\Proxy\Proxy';
+
+    /**
      * @param SchemaFactoryInterface $factory
      * @param array                  $schemas
      */
@@ -189,6 +194,11 @@ class Container implements ContainerInterface, LoggerAwareInterface
      */
     protected function getResourceType($resource)
     {
+
+        if(in_array(self::DOCTRINE_PROXY_CLASS_NAME, class_implements($resource))){
+            return get_parent_class($resource);
+        }
+
         return get_class($resource);
     }
 }


### PR DESCRIPTION
When using in a Symfony application  with Doctrine entities, the resource type is not detected correctly. This happens in case of ManyToOne/ManyToMany relations between entities.
