### PR TITLE
Treat ArrayAccess objects as arrays

### DIFF
--- a/src/Encoder/Parser/Parser.php
+++ b/src/Encoder/Parser/Parser.php
@@ -17,6 +17,7 @@
  */
 
 use \Iterator;
+use \ArrayAccess;
 use \InvalidArgumentException;
 use \Psr\Log\LoggerAwareTrait;
 use \Psr\Log\LoggerAwareInterface;
@@ -206,7 +207,7 @@ class Parser implements ParserInterface, LoggerAwareInterface
         $isOk = (is_array($data) === true || is_object($data) === true || $data === null || $data instanceof Iterator);
         $isOk ?: Exceptions::throwInvalidArgument('data', $data);
 
-        if (is_array($data) === true) {
+        if (is_array($data) === true || $data instanceof ArrayAccess) {
             /** @var array $data */
             $isEmpty = empty($data);
             $traversableData = $data;


### PR DESCRIPTION
The Parser will now check for both native arrays and ArrayAccess objects when analyzing data. This will allow passing in of objects such as [Illuminate's Collection](https://github.com/laravel/framework/blob/5.2/src/Illuminate/Support/Collection.php) into the Encoder's [encodeData](https://github.com/neomerx/json-api/blob/master/src/Encoder/Encoder.php#L151-L160) method.

This can be really useful in a Laravel/Lumen specific project.

Update example:

``` php
// Previously, if $quotesCollection is a Collection object, you must access the inner array via a method.
$encoder->encodeData($quotesCollection->all());

// With this pull request, you can simply pass the Collection object, since it implements ArrayAccess.
$encoder->encodeData($quotesCollection);
```
