### PR TITLE
Pass custom headers via ResponsesInterface

### DIFF
--- a/src/Contracts/Http/ResponsesInterface.php
+++ b/src/Contracts/Http/ResponsesInterface.php
@@ -46,10 +46,17 @@ interface ResponsesInterface
      * @param int          $statusCode
      * @param array|null   $links
      * @param mixed        $meta
+     * @param array        $headers
      *
      * @return mixed
      */
-    public function getContentResponse($data, $statusCode = self::HTTP_OK, $links = null, $meta = null);
+    public function getContentResponse(
+        $data,
+        $statusCode = self::HTTP_OK,
+        $links = null,
+        $meta = null,
+        array $headers = []
+    );
 
     /**
      * Get response for newly created resource with HTTP code 201 (adds 'location' header).
@@ -57,38 +64,41 @@ interface ResponsesInterface
      * @param object     $resource
      * @param array|null $links
      * @param mixed      $meta
+     * @param array      $headers
      *
      * @return mixed
      */
-    public function getCreatedResponse($resource, $links = null, $meta = null);
-
+    public function getCreatedResponse($resource, $links = null, $meta = null, array $headers = []);
 
     /**
      * Get response with HTTP code only.
      *
-     * @param $statusCode
+     * @param int   $statusCode
+     * @param array $headers
      *
      * @return mixed
      */
-    public function getCodeResponse($statusCode);
+    public function getCodeResponse($statusCode, array $headers = []);
 
     /**
      * Get response with meta information only.
      *
      * @param array|object $meta       Meta information.
      * @param int          $statusCode
+     * @param array        $headers
      *
      * @return mixed
      */
-    public function getMetaResponse($meta, $statusCode = self::HTTP_OK);
+    public function getMetaResponse($meta, $statusCode = self::HTTP_OK, array $headers = []);
 
     /**
      * Get response with JSON API Error in body.
      *
      * @param Error|Error[]|ErrorCollection $errors
      * @param int                           $statusCode
+     * @param array                         $headers
      *
      * @return mixed
      */
-    public function getErrorResponse($errors, $statusCode = self::HTTP_BAD_REQUEST);
+    public function getErrorResponse($errors, $statusCode = self::HTTP_BAD_REQUEST, array $headers = []);
 }

--- a/src/Http/Responses.php
+++ b/src/Http/Responses.php
@@ -81,26 +81,31 @@ abstract class Responses implements ResponsesInterface
     /**
      * @inheritdoc
      */
-    public function getContentResponse($data, $statusCode = self::HTTP_OK, $links = null, $meta = null)
-    {
+    public function getContentResponse(
+        $data,
+        $statusCode = self::HTTP_OK,
+        $links = null,
+        $meta = null,
+        array $headers = []
+    ) {
         $encoder = $this->getEncoder();
         $links === null ?: $encoder->withLinks($links);
         $meta === null ?: $encoder->withMeta($meta);
         $content = $encoder->encodeData($data, $this->getEncodingParameters());
 
-        return $this->createJsonApiResponse($content, $statusCode);
+        return $this->createJsonApiResponse($content, $statusCode, $headers);
     }
 
     /**
      * @inheritdoc
      */
-    public function getCreatedResponse($resource, $links = null, $meta = null)
+    public function getCreatedResponse($resource, $links = null, $meta = null, array $headers = [])
     {
         $encoder = $this->getEncoder();
         $links === null ?: $encoder->withLinks($links);
         $meta === null ?: $encoder->withMeta($meta);
         $content = $encoder->encodeData($resource, $this->getEncodingParameters());
-        $headers = [self::HEADER_LOCATION => $this->getResourceLocationUrl($resource)];
+        $headers[self::HEADER_LOCATION] = $this->getResourceLocationUrl($resource);
 
         return $this->createJsonApiResponse($content, self::HTTP_CREATED, $headers);
     }
@@ -108,26 +113,26 @@ abstract class Responses implements ResponsesInterface
     /**
      * @inheritdoc
      */
-    public function getCodeResponse($statusCode)
+    public function getCodeResponse($statusCode, array $headers = [])
     {
-        return $this->createJsonApiResponse(null, $statusCode);
+        return $this->createJsonApiResponse(null, $statusCode, $headers);
     }
 
     /**
      * @inheritdoc
      */
-    public function getMetaResponse($meta, $statusCode = self::HTTP_OK)
+    public function getMetaResponse($meta, $statusCode = self::HTTP_OK, array $headers = [])
     {
         $encoder = $this->getEncoder();
         $content = $encoder->encodeMeta($meta);
 
-        return $this->createJsonApiResponse($content, $statusCode);
+        return $this->createJsonApiResponse($content, $statusCode, $headers);
     }
 
     /**
      * @inheritdoc
      */
-    public function getErrorResponse($errors, $statusCode = self::HTTP_BAD_REQUEST)
+    public function getErrorResponse($errors, $statusCode = self::HTTP_BAD_REQUEST, array $headers = [])
     {
         if ($errors instanceof ErrorCollection || is_array($errors) === true) {
             /** @var Error[] $errors */
@@ -137,7 +142,7 @@ abstract class Responses implements ResponsesInterface
             $content = $this->getEncoder()->encodeError($errors);
         }
 
-        return $this->createJsonApiResponse($content, $statusCode);
+        return $this->createJsonApiResponse($content, $statusCode, $headers);
     }
 
     /**

--- a/tests/Http/ResponsesTest.php
+++ b/tests/Http/ResponsesTest.php
@@ -111,9 +111,21 @@ class ResponsesTest extends BaseTestCase
     }
 
     /**
+     * Test get status code only response, with custom headers.
+     */
+    public function testGetCodeResponse5()
+    {
+        $this->willBeCalledGetMediaType('some', 'type');
+        $this->willBeCalledGetSupportedExtensions(null);
+        $headers = [Responses::HEADER_CONTENT_TYPE => 'some/type', 'X-Custom' => 'Custom-Header'];
+        $this->willBeCalledCreateResponse(null, 123, $headers, 'some response');
+        $this->assertEquals('some response', $this->responses->getCodeResponse(123, ['X-Custom' => 'Custom-Header']));
+    }
+
+    /**
      * Test response.
      */
-    public function testContentResponse()
+    public function testContentResponse1()
     {
         $data = new stdClass();
         $links = ['some' => 'links'];
@@ -127,9 +139,27 @@ class ResponsesTest extends BaseTestCase
     }
 
     /**
+     * Test content response, with customer headers.
+     */
+    public function testContentResponse2()
+    {
+        $data = new stdClass();
+        $links = ['some' => 'links'];
+        $meta  = ['some' => 'meta'];
+        $this->willBeCalledGetMediaType('some', 'type');
+        $this->willBeCalledGetSupportedExtensions(null);
+        $this->willBeCalledEncoderForData($data, 'some json api', $links, $meta);
+        $headers = [Responses::HEADER_CONTENT_TYPE => 'some/type', 'X-Custom' => 'Custom-Header'];
+        $this->willBeCalledCreateResponse('some json api', 321, $headers, 'some response');
+        $this->assertEquals('some response', $this->responses->getContentResponse($data, 321, $links, $meta, [
+            'X-Custom' => 'Custom-Header',
+        ]));
+    }
+
+    /**
      * Test response.
      */
-    public function testCreatedResponse()
+    public function testCreatedResponse1()
     {
         $resource = new stdClass();
         $links    = ['some' => 'links'];
@@ -147,9 +177,32 @@ class ResponsesTest extends BaseTestCase
     }
 
     /**
+     * Test response, with custom headers
+     */
+    public function testCreatedResponse2()
+    {
+        $resource = new stdClass();
+        $links    = ['some' => 'links'];
+        $meta     = ['some' => 'meta'];
+        $this->willBeCalledGetMediaType('some', 'type');
+        $this->willBeCalledGetSupportedExtensions(null);
+        $this->willBeCalledEncoderForData($resource, 'some json api', $links, $meta);
+        $this->willBeCreatedResourceLocationUrl($resource, 'http://server.tld', '/resource-type/123');
+        $headers = [
+            Responses::HEADER_CONTENT_TYPE => 'some/type',
+            Responses::HEADER_LOCATION     => 'http://server.tld/resource-type/123',
+            'X-Custom' => 'Custom-Header',
+        ];
+        $this->willBeCalledCreateResponse('some json api', Responses::HTTP_CREATED, $headers, 'some response');
+        $this->assertEquals('some response', $this->responses->getCreatedResponse($resource, $links, $meta, [
+            'X-Custom' => 'Custom-Header',
+        ]));
+    }
+
+    /**
      * Test response.
      */
-    public function testMetaResponse()
+    public function testMetaResponse1()
     {
         $meta = new stdClass();
         $this->willBeCalledGetMediaType('some', 'type');
@@ -158,6 +211,22 @@ class ResponsesTest extends BaseTestCase
         $headers = [Responses::HEADER_CONTENT_TYPE => 'some/type'];
         $this->willBeCalledCreateResponse('some json api', 321, $headers, 'some response');
         $this->assertEquals('some response', $this->responses->getMetaResponse($meta, 321));
+    }
+
+    /**
+     * Test response, with custom headers
+     */
+    public function testMetaResponse2()
+    {
+        $meta = new stdClass();
+        $this->willBeCalledGetMediaType('some', 'type');
+        $this->willBeCalledGetSupportedExtensions(null);
+        $this->willBeCalledEncoderForMeta($meta, 'some json api');
+        $headers = [Responses::HEADER_CONTENT_TYPE => 'some/type', 'X-Custom' => 'Custom-Header'];
+        $this->willBeCalledCreateResponse('some json api', 321, $headers, 'some response');
+        $this->assertEquals('some response', $this->responses->getMetaResponse($meta, 321, [
+            'X-Custom' => 'Custom-Header',
+        ]));
     }
 
     /**
@@ -201,6 +270,22 @@ class ResponsesTest extends BaseTestCase
         $headers = [Responses::HEADER_CONTENT_TYPE => 'some/type'];
         $this->willBeCalledCreateResponse('some json api', 321, $headers, 'some response');
         $this->assertEquals('some response', $this->responses->getErrorResponse($errors, 321));
+    }
+
+    /**
+     * Test response, with custom headers.
+     */
+    public function testErrorResponse4()
+    {
+        $error = new Error();
+        $this->willBeCalledGetMediaType('some', 'type');
+        $this->willBeCalledGetSupportedExtensions(null);
+        $this->willBeCalledEncoderForError($error, 'some json api');
+        $headers = [Responses::HEADER_CONTENT_TYPE => 'some/type', 'X-Custom' => 'Custom-Header'];
+        $this->willBeCalledCreateResponse('some json api', 321, $headers, 'some response');
+        $this->assertEquals('some response', $this->responses->getErrorResponse($error, 321, [
+            'X-Custom' => 'Custom-Header',
+        ]));
     }
 
     /**

--- a/tests/Http/ResponsesTest.php
+++ b/tests/Http/ResponsesTest.php
@@ -139,7 +139,7 @@ class ResponsesTest extends BaseTestCase
     }
 
     /**
-     * Test content response, with customer headers.
+     * Test content response, with custom headers.
      */
     public function testContentResponse2()
     {


### PR DESCRIPTION
Changes to `ResponsesInterface` to allow additional headers to be passed when creating responses. See issue #132
