### PR TITLE
Use function instead of varible to preserve flexibility

### DIFF
--- a/src/Schema/SchemaProvider.php
+++ b/src/Schema/SchemaProvider.php
@@ -79,7 +79,7 @@ abstract class SchemaProvider implements SchemaProviderInterface
      */
     public function __construct(SchemaFactoryInterface $factory, ContainerInterface $container)
     {
-        $isOk = (is_string($this->resourceType) === true && empty($this->resourceType) === false);
+        $isOk = (is_string($this->getResourceType()) === true && empty($this->getResourceType()) === false);
         if ($isOk === false) {
             throw new InvalidArgumentException(T::t('Resource type is not set for Schema \'%s\'.', [static::class]));
         }


### PR DESCRIPTION
Using variable instead of function does not work great in some environment where the value of type is set by function not variable. Using variable instead makes the library flexible and consistent with other places where method call is used instead of variables.
