### PR TITLE
enable php 7.1 in travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
 - 5.6
 - hhvm
 - 7
+- 7.1
 matrix:
   include:
     - php: 5.5


### PR DESCRIPTION
Hi,

PHP 7.1 have been released and now used in production by some people, is it possible to activate it on your library ?

Thanks