### PR TITLE
Added logic to check Traversable

### DIFF
--- a/src/Encoder/Parser/Parser.php
+++ b/src/Encoder/Parser/Parser.php
@@ -289,10 +289,10 @@ class Parser implements ParserInterface, LoggerAwareInterface
             $traversableData = $data;
         } elseif ($data instanceof Traversable) {
             if ($data instanceof IteratorAggregate
-                && is_object(current(current($data->getIterator())))
+                && is_object(current($data->getIterator()))
             ) {
                 $traversableData = $data->getIterator();
-            } elseif ($data instanceof Iterator) {
+            } elseif ($data instanceof Iterator || in_array('Iterator', class_implements($data))) {
                 $traversableData = $data;
             } else {
                 $isCollection    = false;

--- a/src/Encoder/Parser/Parser.php
+++ b/src/Encoder/Parser/Parser.php
@@ -288,7 +288,16 @@ class Parser implements ParserInterface, LoggerAwareInterface
         if (is_array($data) === true) {
             $traversableData = $data;
         } elseif ($data instanceof Traversable) {
-            $traversableData = $data instanceof IteratorAggregate ? $data->getIterator() : $data;
+            if ($data instanceof IteratorAggregate
+                && is_object(current(current($data->getIterator())))
+            ) {
+                $traversableData = $data->getIterator();
+            } elseif ($data instanceof Iterator) {
+                $traversableData = $data;
+            } else {
+                $isCollection    = false;
+                $traversableData = [$data];
+            }
         } elseif (is_object($data) === true) {
             $isCollection    = false;
             $traversableData = [$data];


### PR DESCRIPTION
The site I am working on uses Yii 1.1. The CModel class implements IteratorAggregate, which is Traversable, but it traverses field names and values, not objects. Attempting to parse this data as a collection results in a bunch of "Object expected" errors.

I attempted to add an exception for this case that preserves the original logic:

1. If $data is an IteratorAggregate AND getIterator() returns objects, then the iterator is retrieved.
2. If $data is an Iterator, then it is returned as-is.
3. Otherwise, $data is not a collection, and returned as an array.