### PR TITLE
Mapping now can handle base classes and interfaces as resource types

### DIFF
--- a/src/Schema/Container.php
+++ b/src/Schema/Container.php
@@ -120,7 +120,7 @@ class Container implements ContainerInterface, LoggerAwareInterface
      */
     public function register(string $type, $schema): void
     {
-        if (empty($type) === true || class_exists($type) === false) {
+        if (empty($type) === true || (class_exists($type) === false && interface_exists($type) === false)) {
             throw new InvalidArgumentException(_($this->messages[self::MSG_INVALID_TYPE]));
         }
 
@@ -371,6 +371,12 @@ class Container implements ContainerInterface, LoggerAwareInterface
             'Unable to get a type of the resource as it is not an object.'
         );
 
+        foreach (array_keys($this->getProviderMappings()) as $schema) {
+            if (is_subclass_of($resource, $schema)) {
+                return $schema;
+            }
+        }
+        
         return get_class($resource);
     }
 

--- a/tests/Data/Author.php
+++ b/tests/Data/Author.php
@@ -21,7 +21,7 @@ use stdClass;
 /**
  * @package Neomerx\Tests\JsonApi
  */
-class Author extends stdClass
+class Author extends stdClass implements AuthorInterface
 {
     const ATTRIBUTE_ID         = 'author_id';
     const ATTRIBUTE_FIRST_NAME = 'first_name';

--- a/tests/Data/AuthorInterface.php
+++ b/tests/Data/AuthorInterface.php
@@ -1,0 +1,5 @@
+<?php namespace Neomerx\Tests\JsonApi\Data;
+
+interface AuthorInterface
+{
+}

--- a/tests/Schema/ContainerTest.php
+++ b/tests/Schema/ContainerTest.php
@@ -22,8 +22,10 @@ use Neomerx\JsonApi\Factories\Factory;
 use Neomerx\JsonApi\Schema\Container;
 use Neomerx\Tests\JsonApi\BaseTestCase;
 use Neomerx\Tests\JsonApi\Data\Author;
+use Neomerx\Tests\JsonApi\Data\AuthorInterface;
 use Neomerx\Tests\JsonApi\Data\AuthorSchema;
 use Neomerx\Tests\JsonApi\Data\Post;
+use stdClass;
 
 /**
  * @package Neomerx\Tests\JsonApi
@@ -134,6 +136,26 @@ class ContainerTest extends BaseTestCase
         $authorSchema = new AuthorSchema($this->factory);
         $container    = new Container($this->factory, [
             Author::class => $authorSchema,
+        ]);
+
+        $this->assertSame($authorSchema, $container->getSchema(new Author()));
+    }
+
+    public function testRegisterSchemaInstanceWhenInterfaceIsMapped()
+    {
+        $authorSchema = new AuthorSchema($this->factory);
+        $container    = new Container($this->factory, [
+            AuthorInterface::class => $authorSchema,
+        ]);
+
+        $this->assertSame($authorSchema, $container->getSchema(new Author()));
+    }
+
+    public function testRegisterSchemaInstanceWhenParentClassIsMapped()
+    {
+        $authorSchema = new AuthorSchema($this->factory);
+        $container    = new Container($this->factory, [
+            stdClass::class => $authorSchema,
         ]);
 
         $this->assertSame($authorSchema, $container->getSchema(new Author()));


### PR DESCRIPTION
Sometimes it can be useful if we can map base classes or interfaces to a schema, not only the leaf classes.

One example:

````php
interface AuthorInterface {}

class Author implements AuthorInterface {
    // ...
}

class AnonymousAuthor implements AuthorInterface {
    // ...
}

$encoder = Encoder::instance([
    AuthorInterface::class => AuthorSchema::class,
], new EncoderOptions(JSON_PRETTY_PRINT, 'http://example.com/api/v1'));

echo $encoder->encodeData(new Author('John Doe'));
echo $encoder->encodeData(new AnonymousAuthor());
````