### PR TITLE
Fix iterating over relationship data generator when generator is empty #252

### DIFF
--- a/src/Parser/RelationshipData/RelationshipDataIsCollection.php
+++ b/src/Parser/RelationshipData/RelationshipDataIsCollection.php
@@ -128,6 +128,7 @@ class RelationshipDataIsCollection extends BaseRelationshipData implements Relat
     public function getResources(): iterable
     {
         if ($this->parsedResources === null) {
+            $this->parsedResources = [];
             foreach ($this->resources as $resourceOrIdentifier) {
                 $parsedResource          = $resourceOrIdentifier instanceof SchemaIdentifierInterface ?
                     $this->createParsedIdentifier($resourceOrIdentifier) :

--- a/tests/Data/Models/Post.php
+++ b/tests/Data/Models/Post.php
@@ -45,7 +45,7 @@ class Post extends stdClass
         string $title,
         string $body,
         Author $author = null,
-        array $comments = []
+        iterable $comments = []
     ) {
         $post = new self();
 

--- a/tests/Encoder/EncodeIncludedObjectsTest.php
+++ b/tests/Encoder/EncodeIncludedObjectsTest.php
@@ -156,12 +156,16 @@ EOL;
      */
     public function testEncodeWithIncludedGenerator(): void
     {
+        $func = function () {
+            yield from $this->comments;
+        };
+
         $this->post = Post::instance(
             1,
             'JSON API paints my bikeshed!',
             'Outside every fat man there was an even fatter man trying to close in',
             $this->author,
-            (function () { yield from $this->comments; })()
+            $func()
         );
 
         $actual = Encoder::instance(
@@ -238,12 +242,16 @@ EOL;
      */
     public function testEncodeWithIncludedEmptyGenerator(): void
     {
+        $func = function () {
+            yield from [];
+        };
+
         $this->post = Post::instance(
             1,
             'JSON API paints my bikeshed!',
             'Outside every fat man there was an even fatter man trying to close in',
             $this->author,
-            (function () { yield from []; })()
+            $func()
         );
 
         $actual = Encoder::instance(


### PR DESCRIPTION
As described in the issue, if relationship data was an empty generator, an error would be triggered as the generator was iterated over twice when including related resources.

This is because the cache in `RelationshipDataIsCollection` was not being set to an empty array.

This PR adds two tests: one for a non-empty generator, and another for an empty generator. The empty generator test was failing before the single line fix was put into `RelationshipDataIsCollection`.

Closes #252